### PR TITLE
Fix parsing of Java checkstyle output

### DIFF
--- a/beefore/checks/javacheckstyle.py
+++ b/beefore/checks/javacheckstyle.py
@@ -10,7 +10,7 @@ from beefore import diff
 
 
 LABEL = 'Java CheckStyle'
-LINT_OUTPUT = re.compile("\[checkstyle\] \[(ERROR)\] (.*?):(\d+): (.*) \[(.*)\]")
+LINT_OUTPUT = re.compile("\[checkstyle\] \[(ERROR)\] (.*?):(\d+):(?:\d+:)? (.*) \[(.*)\]")
 
 
 class Lint:


### PR DESCRIPTION
- Add an optional, non-capturing group to the LINT_OUTPUT regex in order
to let the earlier capture obtain the line number instead of the column
number, when the format is `/path/to/file:line:col:`.
- This revision still permits it to capture the line number when the
column number is not present and format is `/path/to/file:line:`.

Fixes #12 

Caveat: I haven't figured out how to test this locally yet, so this PR is coming in blind... 